### PR TITLE
New conclusion on how go sort the key in map

### DIFF
--- a/content/go1.md
+++ b/content/go1.md
@@ -245,7 +245,7 @@ Nếu viết hoa, var/function/type đó sẽ trở thành "public", code bên n
 [https://play.golang.org/p/SCW8F0EqCmW](https://play.golang.org/p/SCW8F0EqCmW)
 
 - map: giống dict của Python, key phải so sánh `==` được, map và slice không
-làm key được, key không theo thứ tự (unordered). Map trong Go dùng khi cần nối
+làm key được, thứ tự key là ngẫu nhiên. Map trong Go dùng khi cần nối
 key-value, tìm kiếm nhanh, nhưng không dùng như 1 object như dict Python
 `{"name": "Pymier", "age": 20}`,
 do map phải có kiểu cố định cho key, value. [Xem code](https://play.golang.org/p/JRu3lp_mEGj)


### PR DESCRIPTION
@hvnsweeting 
Với Golang, sắp xếp key trong map là ngẫu nhiên khi duyệt bằng range. Điều này được mô tả trong [đây](https://blog.golang.org/maps#TOC_7.)

> When iterating over a map with a range loop, the iteration order is not specified and is not guaranteed to be the same from one iteration to the next.

[Link play ground bằng chứng](https://play.golang.org/p/QfhrNPq9WzT)
![Screenshot from 2021-05-21 10-09-03](https://user-images.githubusercontent.com/26595131/119077568-b3027500-ba1e-11eb-9d60-8bef6b70b44f.png)
